### PR TITLE
Add basic PHP framework with OAuth placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# UserCandy
-UserCandy Framework
+# UserCandy Framework
+
+UserCandy is a simple PHP/MySQL website framework with optional Node.js support. It provides a basic login system, routing, and default pages that can be customized without modifying the core.
+
+## Requirements
+- PHP 7.4+
+- MySQL
+- Node.js (optional for running `server.js`)
+
+## Installation
+1. Copy `core/config.sample.php` to `app/config.php` and update your database credentials and OAuth settings.
+2. Create a MySQL database and run the following to create the users table:
+   ```sql
+   CREATE TABLE users (
+     id INT AUTO_INCREMENT PRIMARY KEY,
+     email VARCHAR(255) UNIQUE NOT NULL,
+     password VARCHAR(255) NOT NULL
+   );
+   ```
+3. Serve the project with your preferred web server pointing to `index.php`.
+4. (Optional) Run `npm install` and `node server.js` to start the Node server.
+
+## Customization
+Add or modify pages in the `app/pages` directory. Files in this folder override files in `pages` with the same name, allowing upgrades without overwriting custom code.
+
+## OAuth Login
+Enable Google, Discord, or Windows login by setting the appropriate flags and credentials in `app/config.php`.
+
+## Default Pages
+- `/` – Home
+- `/login` – Login page
+- `/register` – Registration page
+- `/dashboard` – Protected user dashboard
+
+Enjoy building with UserCandy!

--- a/app/config.php
+++ b/app/config.php
@@ -1,0 +1,19 @@
+<?php
+return [
+    'db' => [
+        'host' => 'localhost',
+        'name' => 'usercandy',
+        'user' => 'root',
+        'pass' => '',
+    ],
+    'base_url' => '/',
+    'enable_google_login' => false,
+    'google_client_id' => '',
+    'google_client_secret' => '',
+    'enable_discord_login' => false,
+    'discord_client_id' => '',
+    'discord_client_secret' => '',
+    'enable_windows_login' => false,
+    'windows_client_id' => '',
+    'windows_client_secret' => '',
+];

--- a/app/pages/custom_example.php
+++ b/app/pages/custom_example.php
@@ -1,0 +1,11 @@
+<?php include __DIR__ . '/../../core/init.php'; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Custom Page</title>
+</head>
+<body>
+<h1>This is a custom page.</h1>
+<p>You can modify or add new pages in the app/pages directory.</p>
+</body>
+</html>

--- a/core/auth.php
+++ b/core/auth.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__ . '/init.php';
+
+function register_user($email, $password) {
+    global $db;
+    $stmt = $db->prepare('INSERT INTO users (email, password) VALUES (?, ?)');
+    return $stmt->execute([$email, password_hash($password, PASSWORD_DEFAULT)]);
+}
+
+function get_user_by_email($email) {
+    global $db;
+    $stmt = $db->prepare('SELECT * FROM users WHERE email = ?');
+    $stmt->execute([$email]);
+    return $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+function login_user($user) {
+    $_SESSION['user_id'] = $user['id'];
+}
+
+function current_user() {
+    global $db;
+    if (!isset($_SESSION['user_id'])) return null;
+    $stmt = $db->prepare('SELECT * FROM users WHERE id = ?');
+    $stmt->execute([$_SESSION['user_id']]);
+    return $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+function logout_user() {
+    unset($_SESSION['user_id']);
+    session_destroy();
+}

--- a/core/config.sample.php
+++ b/core/config.sample.php
@@ -1,0 +1,19 @@
+<?php
+return [
+    'db' => [
+        'host' => 'localhost',
+        'name' => 'usercandy',
+        'user' => 'root',
+        'pass' => '',
+    ],
+    'base_url' => '/',
+    'enable_google_login' => false,
+    'google_client_id' => '',
+    'google_client_secret' => '',
+    'enable_discord_login' => false,
+    'discord_client_id' => '',
+    'discord_client_secret' => '',
+    'enable_windows_login' => false,
+    'windows_client_id' => '',
+    'windows_client_secret' => '',
+];

--- a/core/init.php
+++ b/core/init.php
@@ -1,0 +1,22 @@
+<?php
+
+$config = require __DIR__ . '/../app/config.php';
+
+// Database connection
+try {
+    $db = new PDO(
+        "mysql:host={$config['db']['host']};dbname={$config['db']['name']};charset=utf8mb4",
+        $config['db']['user'],
+        $config['db']['pass']
+    );
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (PDOException $e) {
+    die('Database connection failed: ' . $e->getMessage());
+}
+
+session_start();
+
+function base_url($path = '') {
+    global $config;
+    return rtrim($config['base_url'], '/') . '/' . ltrim($path, '/');
+}

--- a/core/router.php
+++ b/core/router.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/init.php';
+
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$path = trim($path, '/');
+
+if ($path === '') {
+    $page = 'home';
+} else {
+    $page = $path;
+}
+
+$pageFile = __DIR__ . '/../pages/' . $page . '.php';
+$customFile = __DIR__ . '/../app/pages/' . $page . '.php';
+
+if (file_exists($customFile)) {
+    include $customFile;
+} elseif (file_exists($pageFile)) {
+    include $pageFile;
+} else {
+    http_response_code(404);
+    echo 'Page not found';
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/core/router.php';

--- a/oauth/callback.php
+++ b/oauth/callback.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__ . '/../core/init.php';
+$provider = $_GET['provider'] ?? '';
+if (!in_array($provider, ['google', 'discord', 'windows'])) {
+    exit('Unknown provider');
+}
+if (!isset($_GET['state']) || $_GET['state'] !== ($_SESSION['oauth_state'] ?? '')) {
+    exit('Invalid state');
+}
+// Normally you would exchange the code for an access token and retrieve user info
+// Here we simply simulate successful login
+$_SESSION['user_id'] = 0; // Placeholder user id for OAuth logins
+unset($_SESSION['oauth_state']);
+header('Location: ' . base_url('dashboard'));

--- a/oauth/discord.php
+++ b/oauth/discord.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../core/init.php';
+if (!$config['enable_discord_login']) {
+    exit('Discord login not enabled');
+}
+$redirect_uri = base_url('oauth/callback.php?provider=discord');
+$client_id = $config['discord_client_id'];
+$scope = urlencode('identify email');
+$state = bin2hex(random_bytes(8));
+$_SESSION['oauth_state'] = $state;
+$url = "https://discord.com/api/oauth2/authorize?response_type=code&client_id={$client_id}&redirect_uri={$redirect_uri}&scope={$scope}&state={$state}";
+header('Location: ' . $url);

--- a/oauth/google.php
+++ b/oauth/google.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../core/init.php';
+if (!$config['enable_google_login']) {
+    exit('Google login not enabled');
+}
+$redirect_uri = base_url('oauth/callback.php?provider=google');
+$client_id = $config['google_client_id'];
+$scope = urlencode('email profile');
+$state = bin2hex(random_bytes(8));
+$_SESSION['oauth_state'] = $state;
+$url = "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id={$client_id}&redirect_uri={$redirect_uri}&scope={$scope}&state={$state}";
+header('Location: ' . $url);

--- a/oauth/windows.php
+++ b/oauth/windows.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../core/init.php';
+if (!$config['enable_windows_login']) {
+    exit('Windows login not enabled');
+}
+$redirect_uri = base_url('oauth/callback.php?provider=windows');
+$client_id = $config['windows_client_id'];
+$scope = urlencode('openid email profile');
+$state = bin2hex(random_bytes(8));
+$_SESSION['oauth_state'] = $state;
+$url = "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize?response_type=code&client_id={$client_id}&redirect_uri={$redirect_uri}&scope={$scope}&state={$state}";
+header('Location: ' . $url);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "usercandy-node",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/pages/dashboard.php
+++ b/pages/dashboard.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__ . '/../core/auth.php';
+$user = current_user();
+if (!$user) {
+    header('Location: ' . base_url('login'));
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="<?php echo base_url('public/css/style.css'); ?>">
+    <title>Dashboard</title>
+</head>
+<body>
+<h1>Dashboard</h1>
+<p>Welcome <?php echo htmlspecialchars($user['email']); ?>!</p>
+<p><a href="<?php echo base_url('logout'); ?>">Logout</a></p>
+</body>
+</html>

--- a/pages/home.php
+++ b/pages/home.php
@@ -1,0 +1,12 @@
+<?php include __DIR__ . '/../core/init.php'; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="<?php echo base_url('public/css/style.css'); ?>">
+    <title>Home</title>
+</head>
+<body>
+<h1>Welcome to UserCandy Framework</h1>
+<p><a href="<?php echo base_url('login'); ?>">Login</a> or <a href="<?php echo base_url('register'); ?>">Register</a></p>
+</body>
+</html>

--- a/pages/login.php
+++ b/pages/login.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__ . '/../core/auth.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = $_POST['email'] ?? '';
+    $password = $_POST['password'] ?? '';
+    $user = get_user_by_email($email);
+    if ($user && password_verify($password, $user['password'])) {
+        login_user($user);
+        header('Location: ' . base_url('dashboard'));
+        exit;
+    } else {
+        $error = 'Invalid credentials';
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="<?php echo base_url('public/css/style.css'); ?>">
+    <title>Login</title>
+</head>
+<body>
+<h1>Login</h1>
+<?php if (!empty($error)) echo '<p>' . $error . '</p>'; ?>
+<form method="post">
+    <input type="email" name="email" placeholder="Email" required>
+    <input type="password" name="password" placeholder="Password" required>
+    <button type="submit">Login</button>
+</form>
+<p><a href="<?php echo base_url('register'); ?>">Register</a></p>
+<?php if ($config['enable_google_login']): ?>
+<a href="<?php echo base_url('oauth/google.php'); ?>">Login with Google</a>
+<?php endif; ?>
+<?php if ($config['enable_discord_login']): ?>
+<a href="<?php echo base_url('oauth/discord.php'); ?>">Login with Discord</a>
+<?php endif; ?>
+<?php if ($config['enable_windows_login']): ?>
+<a href="<?php echo base_url('oauth/windows.php'); ?>">Login with Windows</a>
+<?php endif; ?>
+</body>
+</html>

--- a/pages/logout.php
+++ b/pages/logout.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__ . '/../core/auth.php';
+logout_user();
+header('Location: ' . base_url());
+exit;

--- a/pages/register.php
+++ b/pages/register.php
@@ -1,0 +1,31 @@
+<?php
+require_once __DIR__ . '/../core/auth.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = $_POST['email'] ?? '';
+    $password = $_POST['password'] ?? '';
+    if (register_user($email, $password)) {
+        header('Location: ' . base_url('login'));
+        exit;
+    } else {
+        $error = 'Registration failed';
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="<?php echo base_url('public/css/style.css'); ?>">
+    <title>Register</title>
+</head>
+<body>
+<h1>Register</h1>
+<?php if (!empty($error)) echo '<p>' . $error . '</p>'; ?>
+<form method="post">
+    <input type="email" name="email" placeholder="Email" required>
+    <input type="password" name="password" placeholder="Password" required>
+    <button type="submit">Register</button>
+</form>
+<p><a href="<?php echo base_url('login'); ?>">Login</a></p>
+</body>
+</html>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,2 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+h1 { color: #333; }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,0 +1,1 @@
+console.log('UserCandy JS loaded');

--- a/server.js
+++ b/server.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.static('public'));
+
+app.get('/api/hello', (req, res) => {
+  res.json({ message: 'Hello from Node!' });
+});
+
+app.listen(port, () => {
+  console.log(`Node server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- implement simple PHP framework with routing and auth
- add optional OAuth placeholders for Google/Discord/Windows
- include Node `server.js` for basic API usage
- document setup and customization in README

## Testing
- `node -v`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686139f5e9c48332a44b4d72baafa5b3