### PR TITLE
Add reCAPTCHA login/register example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # UserCandy
+
 UserCandy Framework
+
+This example includes basic login and registration pages that use Google reCAPTCHA
+when the provider is not `windows`, `google`, or `discord`.
+
+## Setup
+
+1. Copy `config.php` and replace `RECAPTCHA_SITE_KEY` and `RECAPTCHA_SECRET_KEY`
+   with your credentials from the Google reCAPTCHA admin console.
+2. Access `login.php` or `register.php`. Append `?provider=local` to enforce
+   reCAPTCHA or `?provider=google` to skip it.
+
+These pages are placeholders and should be extended with actual authentication
+logic.

--- a/config.php
+++ b/config.php
@@ -1,0 +1,5 @@
+<?php
+// Configuration for reCAPTCHA keys
+// Replace the placeholders with your actual keys
+const RECAPTCHA_SITE_KEY = 'ENTER_SITE_KEY_HERE';
+const RECAPTCHA_SECRET_KEY = 'ENTER_SECRET_KEY_HERE';

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,24 @@
+<?php
+require_once __DIR__ . '/config.php';
+
+/**
+ * Verify reCAPTCHA token with Google API
+ *
+ * @param string $token User response token provided by the reCAPTCHA client-side integration.
+ * @return bool True if token is valid, false otherwise.
+ */
+function verifyRecaptcha(string $token): bool
+{
+    if (empty($token)) {
+        return false;
+    }
+
+    $response = file_get_contents(
+        'https://www.google.com/recaptcha/api/siteverify?secret=' . urlencode(RECAPTCHA_SECRET_KEY) . '&response=' . urlencode($token)
+    );
+    if ($response === false) {
+        return false;
+    }
+    $result = json_decode($response, true);
+    return isset($result['success']) && $result['success'] === true;
+}

--- a/login.php
+++ b/login.php
@@ -1,0 +1,46 @@
+<?php
+require_once __DIR__ . '/functions.php';
+
+$provider = $_GET['provider'] ?? 'local';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+    $token = $_POST['g-recaptcha-response'] ?? '';
+
+    if (!in_array($provider, ['windows', 'google', 'discord'])) {
+        if (!verifyRecaptcha($token)) {
+            $error = 'reCAPTCHA validation failed.';
+        }
+    }
+
+    if (!isset($error)) {
+        // TODO: implement actual authentication logic
+        $message = 'Login successful (placeholder).';
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+</head>
+<body>
+<h1>Login</h1>
+<?php if (!empty($error)): ?>
+    <p style="color:red;"><?= htmlspecialchars($error) ?></p>
+<?php elseif (!empty($message)): ?>
+    <p style="color:green;"><?= htmlspecialchars($message) ?></p>
+<?php endif; ?>
+<form method="post" action="?provider=<?= htmlspecialchars($provider) ?>">
+    <label>Username:<br><input type="text" name="username"></label><br>
+    <label>Password:<br><input type="password" name="password"></label><br>
+    <?php if (!in_array($provider, ['windows', 'google', 'discord'])): ?>
+        <div class="g-recaptcha" data-sitekey="<?= htmlspecialchars(RECAPTCHA_SITE_KEY) ?>"></div>
+    <?php endif; ?>
+    <br>
+    <button type="submit">Login</button>
+</form>
+</body>
+</html>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,50 @@
+<?php
+require_once __DIR__ . '/functions.php';
+
+$provider = $_GET['provider'] ?? 'local';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+    $token = $_POST['g-recaptcha-response'] ?? '';
+
+    if (!in_array($provider, ['windows', 'google', 'discord'])) {
+        if (!verifyRecaptcha($token)) {
+            $error = 'reCAPTCHA validation failed.';
+        }
+    }
+
+    if (!isset($error)) {
+        // TODO: implement actual registration logic
+        $message = 'Registration successful (placeholder).';
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Register</title>
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+</head>
+<body>
+<h1>Register</h1>
+<?php if (!empty($error)): ?>
+    <p style="color:red;">
+        <?= htmlspecialchars($error) ?>
+    </p>
+<?php elseif (!empty($message)): ?>
+    <p style="color:green;">
+        <?= htmlspecialchars($message) ?>
+    </p>
+<?php endif; ?>
+<form method="post" action="?provider=<?= htmlspecialchars($provider) ?>">
+    <label>Username:<br><input type="text" name="username"></label><br>
+    <label>Password:<br><input type="password" name="password"></label><br>
+    <?php if (!in_array($provider, ['windows', 'google', 'discord'])): ?>
+        <div class="g-recaptcha" data-sitekey="<?= htmlspecialchars(RECAPTCHA_SITE_KEY) ?>"></div>
+    <?php endif; ?>
+    <br>
+    <button type="submit">Register</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create example login and register pages using Google reCAPTCHA
- add simple reCAPTCHA verification helper
- add config with placeholder keys
- document the setup in README

## Testing
- `php -l config.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686153aac8ec8332a5ade81f98e34843