### PR TITLE
Add basic bot prevention and reCAPTCHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Add or modify pages in the `app/pages` directory. Files in this folder override 
 
 ## OAuth Login
 Enable Google, Discord, or Windows login by setting the appropriate flags and credentials in `app/config.php`.
+You may also enable Google reCAPTCHA on the login and registration forms by
+setting `enable_recaptcha` to `true` and providing your site and secret keys.
 
 ## Default Pages
 - `/` – Home

--- a/app/config.php
+++ b/app/config.php
@@ -16,4 +16,8 @@ return [
     'enable_windows_login' => false,
     'windows_client_id' => '',
     'windows_client_secret' => '',
+    // Enable Google reCAPTCHA on login and register forms
+    'enable_recaptcha' => false,
+    'recaptcha_site_key' => '',
+    'recaptcha_secret_key' => '',
 ];

--- a/core/auth.php
+++ b/core/auth.php
@@ -30,3 +30,49 @@ function logout_user() {
     unset($_SESSION['user_id']);
     session_destroy();
 }
+
+function request_from_same_site() {
+    $host = $_SERVER['HTTP_HOST'] ?? '';
+    if (isset($_SERVER['HTTP_ORIGIN'])) {
+        $originHost = parse_url($_SERVER['HTTP_ORIGIN'], PHP_URL_HOST);
+        if ($originHost && $originHost !== $host) {
+            return false;
+        }
+    }
+    if (isset($_SERVER['HTTP_REFERER'])) {
+        $refererHost = parse_url($_SERVER['HTTP_REFERER'], PHP_URL_HOST);
+        if ($refererHost && $refererHost !== $host) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function verify_recaptcha($response) {
+    global $config;
+    if (!$config['enable_recaptcha']) {
+        return true;
+    }
+    if (empty($response) || empty($config['recaptcha_secret_key'])) {
+        return false;
+    }
+    $data = [
+        'secret' => $config['recaptcha_secret_key'],
+        'response' => $response,
+        'remoteip' => $_SERVER['REMOTE_ADDR'] ?? ''
+    ];
+    $options = [
+        'http' => [
+            'method' => 'POST',
+            'header' => 'Content-type: application/x-www-form-urlencoded',
+            'content' => http_build_query($data)
+        ]
+    ];
+    $context = stream_context_create($options);
+    $verify = file_get_contents('https://www.google.com/recaptcha/api/siteverify', false, $context);
+    if ($verify === false) {
+        return false;
+    }
+    $result = json_decode($verify, true);
+    return !empty($result['success']);
+}

--- a/core/config.sample.php
+++ b/core/config.sample.php
@@ -16,4 +16,8 @@ return [
     'enable_windows_login' => false,
     'windows_client_id' => '',
     'windows_client_secret' => '',
+    // Enable Google reCAPTCHA on login and register forms
+    'enable_recaptcha' => false,
+    'recaptcha_site_key' => '',
+    'recaptcha_secret_key' => '',
 ];

--- a/pages/login.php
+++ b/pages/login.php
@@ -2,15 +2,23 @@
 require_once __DIR__ . '/../core/auth.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $email = $_POST['email'] ?? '';
-    $password = $_POST['password'] ?? '';
-    $user = get_user_by_email($email);
-    if ($user && password_verify($password, $user['password'])) {
-        login_user($user);
-        header('Location: ' . base_url('dashboard'));
-        exit;
+    if (!request_from_same_site()) {
+        $error = 'Invalid request origin';
+    } elseif (!empty($_POST['honeypot'])) {
+        $error = 'Bot detected';
+    } elseif (!verify_recaptcha($_POST['g-recaptcha-response'] ?? '')) {
+        $error = 'Captcha failed';
     } else {
-        $error = 'Invalid credentials';
+        $email = $_POST['email'] ?? '';
+        $password = $_POST['password'] ?? '';
+        $user = get_user_by_email($email);
+        if ($user && password_verify($password, $user['password'])) {
+            login_user($user);
+            header('Location: ' . base_url('dashboard'));
+            exit;
+        } else {
+            $error = 'Invalid credentials';
+        }
     }
 }
 ?>
@@ -24,8 +32,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <h1>Login</h1>
 <?php if (!empty($error)) echo '<p>' . $error . '</p>'; ?>
 <form method="post">
+    <input type="text" name="honeypot" style="display:none" autocomplete="off">
     <input type="email" name="email" placeholder="Email" required>
     <input type="password" name="password" placeholder="Password" required>
+    <?php if ($config['enable_recaptcha'] && !($config['enable_google_login'] || $config['enable_discord_login'] || $config['enable_windows_login'])): ?>
+        <div class="g-recaptcha" data-sitekey="<?php echo $config['recaptcha_site_key']; ?>"></div>
+        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    <?php endif; ?>
     <button type="submit">Login</button>
 </form>
 <p><a href="<?php echo base_url('register'); ?>">Register</a></p>

--- a/pages/register.php
+++ b/pages/register.php
@@ -2,13 +2,21 @@
 require_once __DIR__ . '/../core/auth.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $email = $_POST['email'] ?? '';
-    $password = $_POST['password'] ?? '';
-    if (register_user($email, $password)) {
-        header('Location: ' . base_url('login'));
-        exit;
+    if (!request_from_same_site()) {
+        $error = 'Invalid request origin';
+    } elseif (!empty($_POST['honeypot'])) {
+        $error = 'Bot detected';
+    } elseif (!verify_recaptcha($_POST['g-recaptcha-response'] ?? '')) {
+        $error = 'Captcha failed';
     } else {
-        $error = 'Registration failed';
+        $email = $_POST['email'] ?? '';
+        $password = $_POST['password'] ?? '';
+        if (register_user($email, $password)) {
+            header('Location: ' . base_url('login'));
+            exit;
+        } else {
+            $error = 'Registration failed';
+        }
     }
 }
 ?>
@@ -22,8 +30,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <h1>Register</h1>
 <?php if (!empty($error)) echo '<p>' . $error . '</p>'; ?>
 <form method="post">
+    <input type="text" name="honeypot" style="display:none" autocomplete="off">
     <input type="email" name="email" placeholder="Email" required>
     <input type="password" name="password" placeholder="Password" required>
+    <?php if ($config['enable_recaptcha'] && !($config['enable_google_login'] || $config['enable_discord_login'] || $config['enable_windows_login'])): ?>
+        <div class="g-recaptcha" data-sitekey="<?php echo $config['recaptcha_site_key']; ?>"></div>
+        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    <?php endif; ?>
     <button type="submit">Register</button>
 </form>
 <p><a href="<?php echo base_url('login'); ?>">Login</a></p>


### PR DESCRIPTION
## Summary
- secure login and register pages
- add honeypot fields to detect bots
- verify user origin and integrate Google reCAPTCHA
- document reCAPTCHA configuration
- update sample and app configs

## Testing
- `php -l pages/login.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861549a16708332ba289b9977d2afc7