### PR TITLE
Add profile route and public index

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ UserCandy is a simple PHP/MySQL website framework with optional Node.js support.
      password VARCHAR(255) NOT NULL
    );
    ```
-3. Serve the project with your preferred web server pointing to `index.php`.
+3. Serve the `public` directory as your web root so requests are handled by `public/index.php`.
 4. (Optional) Run `npm install` and `node server.js` to start the Node server.
 
 ## Customization
@@ -25,11 +25,14 @@ Add or modify pages in the `app/pages` directory. Files in this folder override 
 
 ## OAuth Login
 Enable Google, Discord, or Windows login by setting the appropriate flags and credentials in `app/config.php`.
+You may also enable Google reCAPTCHA on the login and registration forms by
+setting `enable_recaptcha` to `true` and providing your site and secret keys.
 
 ## Default Pages
 - `/` – Home
 - `/login` – Login page
 - `/register` – Registration page
 - `/dashboard` – Protected user dashboard
+- `/profile/{id}` – Public user profile by ID
 
 Enjoy building with UserCandy!

--- a/app/config.php
+++ b/app/config.php
@@ -16,4 +16,8 @@ return [
     'enable_windows_login' => false,
     'windows_client_id' => '',
     'windows_client_secret' => '',
+    // Enable Google reCAPTCHA on login and register forms
+    'enable_recaptcha' => false,
+    'recaptcha_site_key' => '',
+    'recaptcha_secret_key' => '',
 ];

--- a/core/auth.php
+++ b/core/auth.php
@@ -14,6 +14,13 @@ function get_user_by_email($email) {
     return $stmt->fetch(PDO::FETCH_ASSOC);
 }
 
+function get_user_by_id($id) {
+    global $db;
+    $stmt = $db->prepare('SELECT * FROM users WHERE id = ?');
+    $stmt->execute([$id]);
+    return $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
 function login_user($user) {
     $_SESSION['user_id'] = $user['id'];
 }
@@ -29,4 +36,50 @@ function current_user() {
 function logout_user() {
     unset($_SESSION['user_id']);
     session_destroy();
+}
+
+function request_from_same_site() {
+    $host = $_SERVER['HTTP_HOST'] ?? '';
+    if (isset($_SERVER['HTTP_ORIGIN'])) {
+        $originHost = parse_url($_SERVER['HTTP_ORIGIN'], PHP_URL_HOST);
+        if ($originHost && $originHost !== $host) {
+            return false;
+        }
+    }
+    if (isset($_SERVER['HTTP_REFERER'])) {
+        $refererHost = parse_url($_SERVER['HTTP_REFERER'], PHP_URL_HOST);
+        if ($refererHost && $refererHost !== $host) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function verify_recaptcha($response) {
+    global $config;
+    if (!$config['enable_recaptcha']) {
+        return true;
+    }
+    if (empty($response) || empty($config['recaptcha_secret_key'])) {
+        return false;
+    }
+    $data = [
+        'secret' => $config['recaptcha_secret_key'],
+        'response' => $response,
+        'remoteip' => $_SERVER['REMOTE_ADDR'] ?? ''
+    ];
+    $options = [
+        'http' => [
+            'method' => 'POST',
+            'header' => 'Content-type: application/x-www-form-urlencoded',
+            'content' => http_build_query($data)
+        ]
+    ];
+    $context = stream_context_create($options);
+    $verify = file_get_contents('https://www.google.com/recaptcha/api/siteverify', false, $context);
+    if ($verify === false) {
+        return false;
+    }
+    $result = json_decode($verify, true);
+    return !empty($result['success']);
 }

--- a/core/config.sample.php
+++ b/core/config.sample.php
@@ -16,4 +16,8 @@ return [
     'enable_windows_login' => false,
     'windows_client_id' => '',
     'windows_client_secret' => '',
+    // Enable Google reCAPTCHA on login and register forms
+    'enable_recaptcha' => false,
+    'recaptcha_site_key' => '',
+    'recaptcha_secret_key' => '',
 ];

--- a/core/router.php
+++ b/core/router.php
@@ -3,12 +3,9 @@ require_once __DIR__ . '/init.php';
 
 $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 $path = trim($path, '/');
-
-if ($path === '') {
-    $page = 'home';
-} else {
-    $page = $path;
-}
+$segments = $path === '' ? [] : explode('/', $path);
+$page = $segments[0] ?? 'home';
+$GLOBALS['routeParams'] = array_slice($segments, 1);
 
 $pageFile = __DIR__ . '/../pages/' . $page . '.php';
 $customFile = __DIR__ . '/../app/pages/' . $page . '.php';

--- a/index.php
+++ b/index.php
@@ -1,2 +1,0 @@
-<?php
-require_once __DIR__ . '/core/router.php';

--- a/pages/dashboard.php
+++ b/pages/dashboard.php
@@ -9,7 +9,7 @@ if (!$user) {
 <!DOCTYPE html>
 <html>
 <head>
-    <link rel="stylesheet" href="<?php echo base_url('public/css/style.css'); ?>">
+    <link rel="stylesheet" href="<?php echo base_url('css/style.css'); ?>">
     <title>Dashboard</title>
 </head>
 <body>

--- a/pages/home.php
+++ b/pages/home.php
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <link rel="stylesheet" href="<?php echo base_url('public/css/style.css'); ?>">
+    <link rel="stylesheet" href="<?php echo base_url('css/style.css'); ?>">
     <title>Home</title>
 </head>
 <body>

--- a/pages/login.php
+++ b/pages/login.php
@@ -2,30 +2,43 @@
 require_once __DIR__ . '/../core/auth.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $email = $_POST['email'] ?? '';
-    $password = $_POST['password'] ?? '';
-    $user = get_user_by_email($email);
-    if ($user && password_verify($password, $user['password'])) {
-        login_user($user);
-        header('Location: ' . base_url('dashboard'));
-        exit;
+    if (!request_from_same_site()) {
+        $error = 'Invalid request origin';
+    } elseif (!empty($_POST['honeypot'])) {
+        $error = 'Bot detected';
+    } elseif (!verify_recaptcha($_POST['g-recaptcha-response'] ?? '')) {
+        $error = 'Captcha failed';
     } else {
-        $error = 'Invalid credentials';
+        $email = $_POST['email'] ?? '';
+        $password = $_POST['password'] ?? '';
+        $user = get_user_by_email($email);
+        if ($user && password_verify($password, $user['password'])) {
+            login_user($user);
+            header('Location: ' . base_url('dashboard'));
+            exit;
+        } else {
+            $error = 'Invalid credentials';
+        }
     }
 }
 ?>
 <!DOCTYPE html>
 <html>
 <head>
-    <link rel="stylesheet" href="<?php echo base_url('public/css/style.css'); ?>">
+    <link rel="stylesheet" href="<?php echo base_url('css/style.css'); ?>">
     <title>Login</title>
 </head>
 <body>
 <h1>Login</h1>
 <?php if (!empty($error)) echo '<p>' . $error . '</p>'; ?>
 <form method="post">
+    <input type="text" name="honeypot" style="display:none" autocomplete="off">
     <input type="email" name="email" placeholder="Email" required>
     <input type="password" name="password" placeholder="Password" required>
+    <?php if ($config['enable_recaptcha'] && !($config['enable_google_login'] || $config['enable_discord_login'] || $config['enable_windows_login'])): ?>
+        <div class="g-recaptcha" data-sitekey="<?php echo $config['recaptcha_site_key']; ?>"></div>
+        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    <?php endif; ?>
     <button type="submit">Login</button>
 </form>
 <p><a href="<?php echo base_url('register'); ?>">Register</a></p>

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__ . '/../core/auth.php';
+
+$userId = $routeParams[0] ?? null;
+if (!$userId || !ctype_digit($userId)) {
+    http_response_code(404);
+    echo 'User not found';
+    return;
+}
+
+$profileUser = get_user_by_id($userId);
+
+if (!$profileUser) {
+    http_response_code(404);
+    echo 'User not found';
+    return;
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="<?php echo base_url('css/style.css'); ?>">
+    <title>Profile</title>
+</head>
+<body>
+<h1>Profile for <?php echo htmlspecialchars($profileUser['email']); ?></h1>
+<p>User ID: <?php echo $profileUser['id']; ?></p>
+</body>
+</html>

--- a/pages/register.php
+++ b/pages/register.php
@@ -2,28 +2,41 @@
 require_once __DIR__ . '/../core/auth.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $email = $_POST['email'] ?? '';
-    $password = $_POST['password'] ?? '';
-    if (register_user($email, $password)) {
-        header('Location: ' . base_url('login'));
-        exit;
+    if (!request_from_same_site()) {
+        $error = 'Invalid request origin';
+    } elseif (!empty($_POST['honeypot'])) {
+        $error = 'Bot detected';
+    } elseif (!verify_recaptcha($_POST['g-recaptcha-response'] ?? '')) {
+        $error = 'Captcha failed';
     } else {
-        $error = 'Registration failed';
+        $email = $_POST['email'] ?? '';
+        $password = $_POST['password'] ?? '';
+        if (register_user($email, $password)) {
+            header('Location: ' . base_url('login'));
+            exit;
+        } else {
+            $error = 'Registration failed';
+        }
     }
 }
 ?>
 <!DOCTYPE html>
 <html>
 <head>
-    <link rel="stylesheet" href="<?php echo base_url('public/css/style.css'); ?>">
+    <link rel="stylesheet" href="<?php echo base_url('css/style.css'); ?>">
     <title>Register</title>
 </head>
 <body>
 <h1>Register</h1>
 <?php if (!empty($error)) echo '<p>' . $error . '</p>'; ?>
 <form method="post">
+    <input type="text" name="honeypot" style="display:none" autocomplete="off">
     <input type="email" name="email" placeholder="Email" required>
     <input type="password" name="password" placeholder="Password" required>
+    <?php if ($config['enable_recaptcha'] && !($config['enable_google_login'] || $config['enable_discord_login'] || $config['enable_windows_login'])): ?>
+        <div class="g-recaptcha" data-sitekey="<?php echo $config['recaptcha_site_key']; ?>"></div>
+        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    <?php endif; ?>
     <button type="submit">Register</button>
 </form>
 <p><a href="<?php echo base_url('login'); ?>">Login</a></p>

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^ index.php [QSA,L]

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/../core/router.php';


### PR DESCRIPTION
## Summary
- move index.php under `public/` and add rewrite rules
- update stylesheets to use new public path
- parse URL segments in router and expose `$routeParams`
- implement `get_user_by_id` helper and new `profile` page
- document public directory requirement and profile route

## Testing
- `php -l pages/login.php` *(fails: `php` not found)*
- `php -l public/index.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861549a16708332ba289b9977d2afc7