### PR TITLE
Implement global error handler with logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Ignore local configuration
 app/config.php
+
+# Log files
+logs/*.log

--- a/core/init.php
+++ b/core/init.php
@@ -1,4 +1,61 @@
 <?php
+if (defined('UC_INIT')) {
+    return;
+}
+define('UC_INIT', true);
+
+// Setup logging directory and file
+$logDir = __DIR__ . '/../logs';
+if (!is_dir($logDir)) {
+    @mkdir($logDir, 0755, true);
+}
+$logFile = $logDir . '/error.log';
+
+function uc_log_error($message) {
+    global $logFile;
+    error_log('[' . date('Y-m-d H:i:s') . '] ' . $message . PHP_EOL, 3, $logFile);
+}
+
+function uc_error_page($message = '') {
+    $home = htmlspecialchars(base_url());
+    header('Content-Type: text/html; charset=UTF-8');
+    echo "<!DOCTYPE html><html><head><meta charset='UTF-8'>";
+    echo "<title>UserCandy Framework - Error</title>";
+    echo "<link href='https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css' rel='stylesheet'>";
+    echo "</head><body class='p-4 font-sans'>";
+    echo "<h1 class='text-2xl font-bold mb-4'>UserCandy Framework - Error</h1>";
+    echo "<p>An unexpected error occurred and has been logged for the administrator.</p>";
+    if ($message) {
+        echo "<pre class='bg-gray-100 p-2 mt-2 overflow-x-auto'>" . htmlspecialchars($message) . "</pre>";
+    }
+    echo "<a href='{$home}' class='text-blue-700'>Go Home</a>";
+    echo "</body></html>";
+    exit;
+}
+
+set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+    uc_log_error("Error [$errno] $errstr in $errfile:$errline");
+    if ($errno & (E_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR)) {
+        http_response_code(500);
+        uc_error_page($errstr);
+    }
+    return false; // use default PHP error handling for non-fatal errors
+});
+
+set_exception_handler(function ($exception) {
+    uc_log_error('Uncaught Exception: ' . $exception->getMessage() . ' in ' . $exception->getFile() . ':' . $exception->getLine());
+    http_response_code(500);
+    uc_error_page($exception->getMessage());
+});
+
+register_shutdown_function(function () {
+    $error = error_get_last();
+    if ($error && in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR])) {
+        uc_log_error('Fatal Error: ' . $error['message'] . ' in ' . $error['file'] . ':' . $error['line']);
+        http_response_code(500);
+        uc_error_page($error['message']);
+    }
+});
 
 $configPath = __DIR__ . '/../app/config.php';
 if (!file_exists($configPath)) {


### PR DESCRIPTION
## Summary
- create `logs/` folder to hold error logs
- log files ignored by git
- add global error handling in `core/init.php`

## Testing
- `node --version`
- *(php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686186918b6083329673ca68b698afd2