### PR TITLE
Enhance templates and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,28 @@ UserCandy is a simple PHP/MySQL website framework. It provides a basic login sys
    ```
 3. Serve the `public` directory as your web root so requests are handled by `public/index.php`.
 
+### Web server configuration
+For Apache you can set the `DocumentRoot` to the `public` folder:
+
+```apache
+<VirtualHost *:80>
+    DocumentRoot /path/to/UserCandy/public
+    <Directory /path/to/UserCandy/public>
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>
+```
+
+The same idea works with other web servers (nginx, etc.) – just point the server root to `public` so all requests go through `public/index.php`.
+
 If `app/config.php` is missing, the framework will display a setup message instead of crashing.
 
 ## Customization
 Add or modify pages in the `app/pages` directory. Files in this folder override files in `pages` with the same name, allowing upgrades without overwriting custom code.
 The templates in the `templates` directory load a header and footer using Tailwind CSS for styling.
 The footer text and other common labels come from the language files so they can be translated easily.
+You can create additional template folders (e.g. `templates/simple`) and set the active template in `app/config.php` using the `template` option. Individual pages may also override the template by setting `$meta['template']` before calling `render_header()`. 
 On first run the `home.php`, `about.php` and `contact.php` pages are automatically copied into `app/pages` so you can edit them without touching the core folder.
 
 ## OAuth Login

--- a/app/default-config.php
+++ b/app/default-config.php
@@ -31,4 +31,14 @@ return [
         'en','de','zh','hi','es','fr','ar','bn','ru','pt',
         'id','ur','ja','sw','mr','te','tr','ta','vi','ko'
     ],
+
+    // Default template directory inside templates/
+    'template' => 'default',
+
+    // Navigation links shown in the header
+    'nav_links' => [
+        ['title' => 'home', 'url' => ''],
+        ['title' => 'about', 'url' => 'about'],
+        ['title' => 'contact', 'url' => 'contact'],
+    ],
 ];

--- a/app/pages/about.php
+++ b/app/pages/about.php
@@ -2,11 +2,11 @@
 $pathPrefix = __DIR__ . '/../../';
 require_once $pathPrefix . 'core/init.php';
 $meta['title'] = 'About';
-include $pathPrefix . 'templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">About</h1>
 <p>This page can be customized by editing <code>app/pages/about.php</code>.</p>
 <?php
-include $pathPrefix . 'templates/footer.php';
+render_footer();
 return;
 ?>

--- a/app/pages/contact.php
+++ b/app/pages/contact.php
@@ -2,11 +2,11 @@
 $pathPrefix = __DIR__ . '/../../';
 require_once $pathPrefix . 'core/init.php';
 $meta['title'] = 'Contact';
-include $pathPrefix . 'templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">Contact</h1>
 <p>Update this page in <code>app/pages/contact.php</code> with your contact details.</p>
 <?php
-include $pathPrefix . 'templates/footer.php';
+render_footer();
 return;
 ?>

--- a/app/pages/custom_example.php
+++ b/app/pages/custom_example.php
@@ -1,11 +1,11 @@
 <?php
 require_once __DIR__ . '/../../core/init.php';
 $meta['title'] = 'Custom Example';
-include __DIR__ . '/../../templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">Custom Example Page</h1>
 <p>You can modify this page in <code>app/pages/custom_example.php</code>.</p>
 <?php
-include __DIR__ . '/../../templates/footer.php';
+render_footer();
 return;
 ?>

--- a/app/pages/home.php
+++ b/app/pages/home.php
@@ -2,9 +2,11 @@
 $pathPrefix = __DIR__ . '/../../';
 include $pathPrefix . 'core/init.php';
 $meta['title'] = 'Home';
-include $pathPrefix . 'templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">Welcome to UserCandy Framework</h1>
+<p>To get started, copy <code>app/default-config.php</code> to <code>app/config.php</code> and edit the database settings.</p>
+<p>Edit files in <code>app/pages</code> to customize content.</p>
 <p><a class="text-blue-700" href="<?php echo base_url('login'); ?>"><?php echo __('login'); ?></a> or <a class="text-blue-700" href="<?php echo base_url('register'); ?>"><?php echo __('register'); ?></a></p>
-<?php include $pathPrefix . 'templates/footer.php';
+<?php render_footer();
 return; ?>

--- a/core/auth.php
+++ b/core/auth.php
@@ -3,8 +3,10 @@ require_once __DIR__ . '/init.php';
 
 function register_user($email, $password, $role = 'member') {
     global $db;
+    $count = $db->query('SELECT COUNT(*) FROM users')->fetchColumn();
+    $roleToUse = $count == 0 ? 'admin' : $role;
     $stmt = $db->prepare('INSERT INTO users (email, password, role) VALUES (?, ?, ?)');
-    return $stmt->execute([$email, password_hash($password, PASSWORD_DEFAULT), $role]);
+    return $stmt->execute([$email, password_hash($password, PASSWORD_DEFAULT), $roleToUse]);
 }
 
 function get_user_by_email($email) {

--- a/core/init.php
+++ b/core/init.php
@@ -91,6 +91,12 @@ $config = require $configPath;
 // Provide sane defaults if optional keys are missing
 $config['language'] = $config['language'] ?? 'en';
 $config['available_languages'] = $config['available_languages'] ?? ['en'];
+$config['template'] = $config['template'] ?? 'default';
+$config['nav_links'] = $config['nav_links'] ?? [
+    ['title' => 'home', 'url' => ''],
+    ['title' => 'about', 'url' => 'about'],
+    ['title' => 'contact', 'url' => 'contact'],
+];
 
 // Language loading
 $langCode = $_GET['lang'] ?? $_SESSION['lang'] ?? $config['language'];
@@ -147,4 +153,23 @@ foreach ($defaults as $p) {
     if (!file_exists($dest) && file_exists($src)) {
         @copy($src, $dest);
     }
+}
+
+function get_template_path($file) {
+    global $config, $meta;
+    $template = $meta['template'] ?? $config['template'];
+    $base = __DIR__ . '/../templates/';
+    if ($template !== 'default') {
+        $alt = $base . $template . '/' . $file;
+        if (file_exists($alt)) return $alt;
+    }
+    return $base . $file;
+}
+
+function render_header() {
+    include get_template_path('header.php');
+}
+
+function render_footer() {
+    include get_template_path('footer.php');
 }

--- a/pages/about.php
+++ b/pages/about.php
@@ -1,11 +1,11 @@
 <?php
 require_once __DIR__ . '/../core/init.php';
 $meta['title'] = 'About';
-include __DIR__ . '/../templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">About</h1>
 <p>This page can be customized by editing <code>app/pages/about.php</code>.</p>
 <?php
-include __DIR__ . '/../templates/footer.php';
+render_footer();
 return;
 ?>

--- a/pages/account.php
+++ b/pages/account.php
@@ -2,12 +2,12 @@
 require_once __DIR__ . '/../core/auth.php';
 $user = require_role('member');
 $meta['title'] = 'Account';
-include __DIR__ . '/../templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">Account</h1>
 <p>Email: <?php echo htmlspecialchars($user['email']); ?></p>
 <p>Role: <?php echo htmlspecialchars($user['role']); ?></p>
 <?php
-include __DIR__ . '/../templates/footer.php';
+render_footer();
 return;
 ?>

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -2,12 +2,12 @@
 require_once __DIR__ . '/../core/auth.php';
 require_role('admin');
 $meta['title'] = 'Admin';
-include __DIR__ . '/../templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">Admin Area</h1>
 <p>Only admins can see this page.</p>
 <p><a class="text-blue-700" href="<?php echo base_url('roles'); ?>">Manage Roles</a></p>
 <?php
-include __DIR__ . '/../templates/footer.php';
+render_footer();
 return;
 ?>

--- a/pages/contact.php
+++ b/pages/contact.php
@@ -1,11 +1,11 @@
 <?php
 require_once __DIR__ . '/../core/init.php';
 $meta['title'] = 'Contact';
-include __DIR__ . '/../templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">Contact</h1>
 <p>Update this page in <code>app/pages/contact.php</code> with your contact details.</p>
 <?php
-include __DIR__ . '/../templates/footer.php';
+render_footer();
 return;
 ?>

--- a/pages/dashboard.php
+++ b/pages/dashboard.php
@@ -5,10 +5,14 @@ add_notification('Visit your profile', base_url('profile/' . $user['id']));
 ?>
 <?php
 $meta['title'] = 'Dashboard';
-include __DIR__ . '/../templates/header.php';
+render_header();
+?>
+<?php $flash = get_flash('success'); if ($flash): ?>
+<script>$(function(){ showPopup('<?php echo addslashes($flash); ?>','success'); });</script>
+<?php endif; ?>
 ?>
 <h1 class="text-2xl font-bold mb-4">Dashboard</h1>
 <p>Welcome <?php echo htmlspecialchars($user['email']); ?>!</p>
 <p><a class="text-blue-700" href="<?php echo base_url('logout'); ?>">Logout</a></p>
-<?php include __DIR__ . '/../templates/footer.php';
+<?php render_footer();
 return; ?>

--- a/pages/home.php
+++ b/pages/home.php
@@ -1,8 +1,10 @@
 <?php include __DIR__ . '/../core/init.php';
 $meta['title'] = 'Home';
-include __DIR__ . '/../templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">Welcome to UserCandy Framework</h1>
+<p>To get started, copy <code>app/default-config.php</code> to <code>app/config.php</code> and edit the database settings.</p>
+<p>Edit files in <code>app/pages</code> to customize content.</p>
 <p><a class="text-blue-700" href="<?php echo base_url('login'); ?>"><?php echo __('login'); ?></a> or <a class="text-blue-700" href="<?php echo base_url('register'); ?>"><?php echo __('register'); ?></a></p>
-<?php include __DIR__ . '/../templates/footer.php';
+<?php render_footer();
 return; ?>

--- a/pages/login.php
+++ b/pages/login.php
@@ -17,6 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if (!empty($_POST['remember'])) {
                 setcookie(session_name(), session_id(), time() + 60 * 60 * 24 * 30, '/');
             }
+            set_flash('success', 'Logged in');
             header('Location: ' . base_url('dashboard'));
             exit;
         } else {
@@ -27,7 +28,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 ?>
 <?php
 $meta['title'] = 'Login';
-include __DIR__ . '/../templates/header.php';
+render_header();
 ?>
 <?php $flash = get_flash('success'); if ($flash): ?>
 <script>$(function(){ showPopup('<?php echo addslashes($flash); ?>', 'success'); });</script>
@@ -65,5 +66,5 @@ document.querySelector('form').addEventListener('submit', function(e) {
     }
 });
 </script>
-<?php include __DIR__ . '/../templates/footer.php';
+<?php render_footer();
 return; ?>

--- a/pages/notifications.php
+++ b/pages/notifications.php
@@ -9,7 +9,7 @@ if (isset($_GET['mark_all'])) {
     exit;
 }
 $meta['title'] = 'Notifications';
-include __DIR__ . '/../templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">Notifications</h1>
 <?php $notifs = get_notifications(); if (!$notifs): ?>
@@ -27,6 +27,6 @@ include __DIR__ . '/../templates/header.php';
 <a class="text-blue-700" href="?mark_all=1">Mark all read</a>
 <?php endif; ?>
 <?php
-include __DIR__ . '/../templates/footer.php';
+render_footer();
 return;
 ?>

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -18,9 +18,9 @@ if (!$profileUser) {
 ?>
 <?php
 $meta['title'] = 'Profile';
-include __DIR__ . '/../templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">Profile for <?php echo htmlspecialchars($profileUser['email']); ?></h1>
 <p>User ID: <?php echo $profileUser['id']; ?></p>
-<?php include __DIR__ . '/../templates/footer.php';
+<?php render_footer();
 return; ?>

--- a/pages/register.php
+++ b/pages/register.php
@@ -23,7 +23,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 ?>
 <?php
 $meta['title'] = 'Register';
-include __DIR__ . '/../templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">Register</h1>
 <?php if (!empty($error)) echo '<p class="text-red-500">' . $error . '</p>'; ?>
@@ -38,5 +38,5 @@ include __DIR__ . '/../templates/header.php';
     <button type="submit" class="bg-blue-500 text-white px-2 py-1">Register</button>
 </form>
 <p><a class="text-blue-700" href="<?php echo base_url('login'); ?>">Login</a></p>
-<?php include __DIR__ . '/../templates/footer.php';
+<?php render_footer();
 return; ?>

--- a/pages/roles.php
+++ b/pages/roles.php
@@ -19,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 $roles = get_roles();
 $meta['title'] = 'Roles';
-include __DIR__ . '/../templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">Manage Roles</h1>
 <?php $flash = get_flash('success'); if ($flash): ?>
@@ -51,4 +51,4 @@ include __DIR__ . '/../templates/header.php';
     <input type="text" name="name" class="border p-1" required>
     <button type="submit" name="add" class="bg-blue-500 text-white px-2 py-1">Add</button>
 </form>
-<?php include __DIR__ . '/../templates/footer.php'; return; ?>
+<?php render_footer(); return; ?>

--- a/pages/users.php
+++ b/pages/users.php
@@ -2,7 +2,7 @@
 require_once __DIR__ . '/../core/auth.php';
 $user = require_role(['staff','admin']);
 $meta['title'] = 'Users';
-include __DIR__ . '/../templates/header.php';
+render_header();
 ?>
 <h1 class="text-2xl font-bold mb-4">Users</h1>
 <div id="loading" class="mb-2">Loading...</div>
@@ -12,5 +12,5 @@ include __DIR__ . '/../templates/header.php';
   </thead>
   <tbody></tbody>
 </table>
-<?php include __DIR__ . '/../templates/footer.php';
+<?php render_footer();
 return; ?>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,4 +1,4 @@
-body { font-family: Arial, sans-serif; margin: 20px; }
+body { font-family: Arial, sans-serif; margin: 0; }
 h1 { color: #333; }
 html.dark body {
     background-color: #1a202c;

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -1,4 +1,5 @@
-    <footer class="mt-8 text-center text-sm text-gray-500"><?php echo __('footer_text'); ?></footer>
+    </main>
+    <footer class="mt-auto bg-gray-800 text-white text-center text-sm p-4"><?php echo __('footer_text'); ?></footer>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="<?php echo base_url('js/script.js'); ?>"></script>
 </body>

--- a/templates/header.php
+++ b/templates/header.php
@@ -13,33 +13,35 @@ if (!isset($meta['title'])) { $meta['title'] = 'UserCandy'; }
     <link rel="stylesheet" href="<?php echo base_url('css/style.css'); ?>">
     <script>const baseUrl = "<?php echo rtrim(base_url(), '/'); ?>/";</script>
 </head>
-<body class="p-4">
-    <nav class="mb-4 flex items-center justify-between">
+<body class="min-h-screen flex flex-col p-4">
+    <nav class="mb-4 flex items-center justify-between bg-blue-600 text-white p-2 sticky top-0 z-10">
         <div class="flex items-center space-x-4">
             <div class="flex items-center space-x-2">
                 <img src="<?php echo base_url('images/userCandyLogo.png'); ?>" alt="UserCandy" class="h-8" />
                 <span class="text-xl font-bold"><?php echo __('site_name'); ?></span>
             </div>
             <ul class="flex space-x-4">
-                <li><a class="text-blue-700" href="<?php echo base_url(); ?>"><?php echo __('home'); ?></a></li>
-                <li><a class="text-blue-700" href="<?php echo base_url('about'); ?>"><?php echo __('about'); ?></a></li>
-                <li><a class="text-blue-700" href="<?php echo base_url('contact'); ?>"><?php echo __('contact'); ?></a></li>
+                <?php foreach ($config['nav_links'] as $l): ?>
+                    <li><a class="hover:underline" href="<?php echo base_url($l['url']); ?>"><?php echo __($l['title']); ?></a></li>
+                <?php endforeach; ?>
             </ul>
         </div>
         <div class="flex items-center space-x-4">
             <button id="theme-toggle" class="focus:outline-none">&#9728;</button>
+            <?php if ($current): ?>
             <div class="relative">
                 <button id="notif-bell" class="focus:outline-none">&#128276;</button>
-                <div id="notif-menu" class="hidden absolute right-0 mt-2 w-56 bg-white border rounded shadow-lg text-sm">
+                <div id="notif-menu" class="hidden absolute right-0 mt-2 w-56 bg-white dark:bg-gray-700 dark:text-white border rounded shadow-lg text-sm">
                     <?php foreach (get_notifications() as $nid => $n): ?>
-                        <a class="block px-2 py-1 hover:bg-gray-100<?php echo empty($n['read']) ? ' font-bold' : ''; ?>" href="<?php echo htmlspecialchars($n['url']) . (strpos($n['url'], '?') !== false ? '&' : '?'); ?>notify=<?php echo $nid; ?>"><?php echo htmlspecialchars($n['title']); ?></a>
+                        <a class="block px-2 py-1 hover:bg-gray-100 dark:hover:bg-gray-600<?php echo empty($n['read']) ? ' font-bold' : ''; ?>" href="<?php echo htmlspecialchars($n['url']) . (strpos($n['url'], '?') !== false ? '&' : '?'); ?>notify=<?php echo $nid; ?>"><?php echo htmlspecialchars($n['title']); ?></a>
                     <?php endforeach; ?>
                     <div class="border-t px-2 py-1">
-                        <a class="text-blue-700 block" href="<?php echo base_url('notifications?mark_all=1'); ?>">Mark all read</a>
-                        <a class="text-blue-700 block" href="<?php echo base_url('notifications'); ?>">View all</a>
+                        <a class="text-blue-200 block" href="<?php echo base_url('notifications?mark_all=1'); ?>">Mark all read</a>
+                        <a class="text-blue-200 block" href="<?php echo base_url('notifications'); ?>">View all</a>
                     </div>
                 </div>
             </div>
+            <?php endif; ?>
             <div class="relative">
                 <?php if ($current = current_user()): ?>
                     <?php if (!empty($current['avatar'])): ?>
@@ -50,7 +52,7 @@ if (!isset($meta['title'])) { $meta['title'] = 'UserCandy'; }
                 <?php else: ?>
                     <span id="user-avatar" class="w-8 h-8 flex items-center justify-center rounded-full bg-gray-300 cursor-pointer">&#128100;</span>
                 <?php endif; ?>
-                <div id="user-menu" class="hidden absolute right-0 mt-2 w-48 bg-white border rounded shadow-lg text-sm p-2">
+                <div id="user-menu" class="hidden absolute right-0 mt-2 w-48 bg-white dark:bg-gray-700 dark:text-white border rounded shadow-lg text-sm p-2">
                     <?php if ($current): ?>
                         <div class="px-2 py-1 border-b">
                             <div><?php echo htmlspecialchars($current['email']); ?></div>
@@ -71,4 +73,5 @@ if (!isset($meta['title'])) { $meta['title'] = 'UserCandy'; }
         </div>
     </nav>
     <div id="popup-container" class="fixed top-4 right-4 space-y-2 z-50"></div>
+    <main class="flex-grow">
 


### PR DESCRIPTION
## Summary
- document how to point Apache to the `public` folder
- allow custom templates with a new `template` option and utility functions
- read navigation links from `config`
- colorize header/footer, make them sticky, and support dark mode menus
- hide notifications when logged out
- show instructions on the default home page
- show login success popup
- set the first user as `admin`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6861e52d11e08332b20076293bf512e2