### PR TITLE
Add Facebook OAuth and refine login UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can create additional template folders (e.g. `templates/simple`) and set the
 On first run the `home.php`, `about.php` and `contact.php` pages are automatically copied into `app/pages` so you can edit them without touching the core folder.
 
 ## OAuth Login
-Enable Google, Discord, or Windows login by setting the appropriate flags and credentials in `app/config.php`.
+Enable Google, Discord, Windows, or Facebook login by setting the appropriate flags and credentials in `app/config.php`.
 You may also enable Google reCAPTCHA on the login and registration forms by
 setting `enable_recaptcha` to `true` and providing your site and secret keys.
 

--- a/app/default-config.php
+++ b/app/default-config.php
@@ -19,6 +19,9 @@ return [
     'enable_windows_login' => false,
     'windows_client_id' => '',
     'windows_client_secret' => '',
+    'enable_facebook_login' => false,
+    'facebook_client_id' => '',
+    'facebook_client_secret' => '',
     // Enable Google reCAPTCHA on login and register forms
     'enable_recaptcha' => false,
     'recaptcha_site_key' => '',

--- a/app/pages/home.php
+++ b/app/pages/home.php
@@ -1,6 +1,6 @@
 <?php
 $pathPrefix = __DIR__ . '/../../';
-include $pathPrefix . 'core/init.php';
+require_once $pathPrefix . 'core/init.php';
 $meta['title'] = 'Home';
 render_header();
 ?>

--- a/core/auth.php
+++ b/core/auth.php
@@ -40,6 +40,15 @@ function logout_user() {
     session_destroy();
 }
 
+function require_login() {
+    $user = current_user();
+    if (!$user) {
+        header('Location: ' . base_url('login'));
+        exit;
+    }
+    return $user;
+}
+
 function require_role($roles) {
     $user = current_user();
     if (!$user) {

--- a/oauth/callback.php
+++ b/oauth/callback.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../core/init.php';
 $provider = $_GET['provider'] ?? '';
-if (!in_array($provider, ['google', 'discord', 'windows'])) {
+if (!in_array($provider, ['google', 'discord', 'windows', 'facebook'])) {
     exit('Unknown provider');
 }
 if (!isset($_GET['state']) || $_GET['state'] !== ($_SESSION['oauth_state'] ?? '')) {

--- a/oauth/facebook.php
+++ b/oauth/facebook.php
@@ -1,0 +1,13 @@
+<?php
+require_once __DIR__ . '/../core/init.php';
+if (!$config['enable_facebook_login']) {
+    exit('Facebook login not enabled');
+}
+$redirect_uri = base_url('oauth/callback.php?provider=facebook');
+$client_id = $config['facebook_client_id'];
+$scope = urlencode('email public_profile');
+$state = bin2hex(random_bytes(8));
+$_SESSION['oauth_state'] = $state;
+$url = "https://www.facebook.com/v12.0/dialog/oauth?response_type=code&client_id={$client_id}&redirect_uri={$redirect_uri}&scope={$scope}&state={$state}";
+header('Location: ' . $url);
+

--- a/pages/account.php
+++ b/pages/account.php
@@ -1,6 +1,6 @@
 <?php
 require_once __DIR__ . '/../core/auth.php';
-$user = require_role('member');
+$user = require_login();
 $meta['title'] = 'Account';
 render_header();
 ?>

--- a/pages/dashboard.php
+++ b/pages/dashboard.php
@@ -1,6 +1,6 @@
 <?php
 require_once __DIR__ . '/../core/auth.php';
-$user = require_role('member');
+$user = require_login();
 add_notification('Visit your profile', base_url('profile/' . $user['id']));
 ?>
 <?php

--- a/pages/home.php
+++ b/pages/home.php
@@ -1,4 +1,4 @@
-<?php include __DIR__ . '/../core/init.php';
+<?php require_once __DIR__ . '/../core/init.php';
 $meta['title'] = 'Home';
 render_header();
 ?>

--- a/pages/login.php
+++ b/pages/login.php
@@ -33,19 +33,27 @@ render_header();
 <?php $flash = get_flash('success'); if ($flash): ?>
 <script>$(function(){ showPopup('<?php echo addslashes($flash); ?>', 'success'); });</script>
 <?php endif; ?>
-<h1 class="text-2xl font-bold mb-4">Login</h1>
-<?php if (!empty($error)) echo '<p class="text-red-500">' . $error . '</p>'; ?>
-<form method="post" class="space-y-2">
+<h1 class="text-2xl font-bold mb-4 text-center">Login</h1>
+<?php if (!empty($error)) echo '<p class="text-red-500 text-center">' . $error . '</p>'; ?>
+<div class="max-w-sm mx-auto p-6 bg-white dark:bg-gray-800 rounded shadow">
+<form method="post" class="space-y-3">
     <input type="text" name="honeypot" style="display:none" autocomplete="off">
-    <input type="email" name="email" placeholder="Email" required class="border p-1">
-    <input type="password" name="password" placeholder="Password" required class="border p-1">
+    <div class="flex items-center border rounded px-2 py-1">
+        <span class="mr-2">&#9993;</span>
+        <input type="email" name="email" placeholder="Email" required class="flex-grow focus:outline-none bg-transparent">
+    </div>
+    <div class="flex items-center border rounded px-2 py-1">
+        <span class="mr-2">&#128274;</span>
+        <input type="password" name="password" placeholder="Password" required class="flex-grow focus:outline-none bg-transparent">
+    </div>
     <label class="block"><input type="checkbox" name="remember" id="remember"> Remember me</label>
-    <?php if ($config['enable_recaptcha'] && !($config['enable_google_login'] || $config['enable_discord_login'] || $config['enable_windows_login'])): ?>
+    <?php if ($config['enable_recaptcha'] && !($config['enable_google_login'] || $config['enable_discord_login'] || $config['enable_windows_login'] || $config['enable_facebook_login'])): ?>
         <div class="g-recaptcha" data-sitekey="<?php echo $config['recaptcha_site_key']; ?>"></div>
         <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     <?php endif; ?>
-    <button type="submit" class="bg-blue-500 text-white px-2 py-1">Login</button>
+    <button type="submit" class="bg-blue-500 text-white px-2 py-1 w-full">Login</button>
 </form>
+</div>
 <p><a class="text-blue-700" href="<?php echo base_url('register'); ?>">Register</a></p>
 <?php if ($config['enable_google_login']): ?>
 <a class="text-blue-700" href="<?php echo base_url('oauth/google.php'); ?>">Login with Google</a>
@@ -56,13 +64,13 @@ render_header();
 <?php if ($config['enable_windows_login']): ?>
 <a class="text-blue-700" href="<?php echo base_url('oauth/windows.php'); ?>">Login with Windows</a>
 <?php endif; ?>
+<?php if ($config['enable_facebook_login']): ?>
+<a class="text-blue-700" href="<?php echo base_url('oauth/facebook.php'); ?>">Login with Facebook</a>
+<?php endif; ?>
 <script>
-document.querySelector('form').addEventListener('submit', function(e) {
-    var cb = document.getElementById('remember');
-    if (cb.checked) {
-        if (!confirm('Stay logged in on this device?')) {
-            cb.checked = false;
-        }
+document.getElementById('remember').addEventListener('change', function(){
+    if(this.checked && !confirm('Stay logged in on this device?')){
+        this.checked = false;
     }
 });
 </script>

--- a/pages/notifications.php
+++ b/pages/notifications.php
@@ -1,6 +1,6 @@
 <?php
 require_once __DIR__ . '/../core/auth.php';
-$user = require_role('member');
+$user = require_login();
 if (isset($_GET['mark_all'])) {
     foreach (get_notifications() as $nid => $_) {
         mark_notification_read($nid);

--- a/pages/register.php
+++ b/pages/register.php
@@ -25,18 +25,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 $meta['title'] = 'Register';
 render_header();
 ?>
-<h1 class="text-2xl font-bold mb-4">Register</h1>
-<?php if (!empty($error)) echo '<p class="text-red-500">' . $error . '</p>'; ?>
-<form method="post" class="space-y-2">
+<h1 class="text-2xl font-bold mb-4 text-center">Register</h1>
+<?php if (!empty($error)) echo '<p class="text-red-500 text-center">' . $error . '</p>'; ?>
+<div class="max-w-sm mx-auto p-6 bg-white dark:bg-gray-800 rounded shadow">
+<form method="post" class="space-y-3">
     <input type="text" name="honeypot" style="display:none" autocomplete="off">
-    <input type="email" name="email" placeholder="Email" required class="border p-1">
-    <input type="password" name="password" placeholder="Password" required class="border p-1">
-    <?php if ($config['enable_recaptcha'] && !($config['enable_google_login'] || $config['enable_discord_login'] || $config['enable_windows_login'])): ?>
+    <div class="flex items-center border rounded px-2 py-1">
+        <span class="mr-2">&#9993;</span>
+        <input type="email" name="email" placeholder="Email" required class="flex-grow focus:outline-none bg-transparent">
+    </div>
+    <div class="flex items-center border rounded px-2 py-1">
+        <span class="mr-2">&#128274;</span>
+        <input type="password" name="password" placeholder="Password" required class="flex-grow focus:outline-none bg-transparent">
+    </div>
+    <?php if ($config['enable_recaptcha'] && !($config['enable_google_login'] || $config['enable_discord_login'] || $config['enable_windows_login'] || $config['enable_facebook_login'])): ?>
         <div class="g-recaptcha" data-sitekey="<?php echo $config['recaptcha_site_key']; ?>"></div>
         <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     <?php endif; ?>
-    <button type="submit" class="bg-blue-500 text-white px-2 py-1">Register</button>
+    <button type="submit" class="bg-blue-500 text-white px-2 py-1 w-full">Register</button>
 </form>
-<p><a class="text-blue-700" href="<?php echo base_url('login'); ?>">Login</a></p>
+</div>
+<p class="text-center mt-2"><a class="text-blue-700" href="<?php echo base_url('login'); ?>">Login</a></p>
 <?php render_footer();
 return; ?>


### PR DESCRIPTION
## Summary
- support Facebook OAuth login
- style login and register forms with icons and centered layout
- add confirmation when remember-me checkbox is toggled
- allow any logged-in user to access dashboard and account pages
- fix home page includes to use `require_once`
- document Facebook login option

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6861e8887e2883328c1973ac0bf95c2f