### PR TITLE
Add config file check and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# UserCandy PHP Framework
+
+UserCandy is a simple PHP MVC framework. This repository contains the core files needed to start building your application.
+
+## Getting Started
+
+1. Copy `system/Config-Example.php` to `system/Config.php`.
+2. Edit `system/Config.php` and update the configuration values for your environment.
+3. Import the `database_default.sql` file into your database.
+4. Configure your web server so the document root points to the `public` directory.
+
+## Requirements
+
+- PHP 8.0 or higher
+- A MySQL compatible database
+
+## Folder Structure
+
+- `public/` - Front controller and public assets
+- `system/` - Framework core files and configuration
+- `views/`  - Application views and templates
+
+## License
+
+UserCandy is open source and released under the MIT license.

--- a/public/index.php
+++ b/public/index.php
@@ -21,8 +21,14 @@ if (file_exists(SYSTEMDIR.'autoloader.php')) {
 }
 
 /* Load the Site Config */
-require(SYSTEMDIR.'Config.php');
-new Config();
+if (file_exists(SYSTEMDIR.'Config.php')) {
+    require SYSTEMDIR.'Config.php';
+    new Config();
+} else {
+    echo "<h1>Configuration Required</h1>";
+    echo "<p>Please rename or copy " . SYSTEMDIR . "Config-Example.php to Config.php and update your settings.</p>";
+    exit;
+}
 
 date_default_timezone_set(TIMEZONE);
 


### PR DESCRIPTION
## Summary
- check for `Config.php` when loading and show instructions when missing
- add modern README for framework

## Testing
- `php -l public/index.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68646370474c83328e30fcbf60e1bfdb