### PR TITLE
Fix account activation default and validation

### DIFF
--- a/system/Config-Example.php
+++ b/system/Config-Example.php
@@ -101,6 +101,9 @@ class Config {
          *                *
          *****************/
         // Account needs email activation, false=no true=yes
+        // NOTE: If enabled, the email configuration values below must be
+        // changed from their defaults or activation will automatically be
+        // disabled at runtime.
         define("ACCOUNT_ACTIVATION", 'false');
         // Max attempts for login before user is locked out
         define("MAX_ATTEMPTS", '5');

--- a/system/helpers/helper.AuthHelper.php
+++ b/system/helpers/helper.AuthHelper.php
@@ -461,6 +461,25 @@ class AuthHelper
                         /** Check to see if Account Activation is required **/
                         $account_activation = ACCOUNT_ACTIVATION;
                         if ($account_activation == "true") {
+                            /**
+                             * Ensure email configuration is properly set.  If
+                             * any of the email related configuration values
+                             * remain at their default placeholders then
+                             * disable account activation so the user can still
+                             * register.
+                             */
+                            $email_defaults = [
+                                EMAIL_FROM_NAME === 'email_from_name',
+                                EMAIL_HOST === 'email_host',
+                                EMAIL_PASSWORD === 'email_password',
+                                SITE_EMAIL === 'email_site'
+                            ];
+                            if (in_array(true, $email_defaults, true)) {
+                                $account_activation = "false";
+                            }
+                        }
+
+                        if ($account_activation == "true") {
                             /** Check if Email Settings are set **/
                             $site_mail_setting = EMAIL_FROM_NAME;
                             if (!empty($site_mail_setting)) {


### PR DESCRIPTION
## Summary
- document that account activation requires real email settings
- disable account activation at runtime if email config still has default placeholders

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646e08fbbc83328287856eb779d28b