### PR TITLE
Fix login user ID retrieval

### DIFF
--- a/views/system/login.php
+++ b/views/system/login.php
@@ -31,7 +31,13 @@ use Models\{UsersModel};
             $username = $email && (count($email) != 0 ) ? $email[0]->userName : $username;
 
             if ($authHelper->login($username, $password, $rememberMe)) {
-                $userId = $authHelper->currentSessionInfo()['uid'];
+                $sessionInfo = $authHelper->currentSessionInfo();
+                if (is_array($sessionInfo) && isset($sessionInfo['uid'])) {
+                    $userId = $sessionInfo['uid'];
+                } else {
+                    // Fallback to fetching the user id from the database
+                    $userId = $usersModel->getUserID($username);
+                }
 
                 /** Update the last login timestamp for user to now **/
                 $info = array('LastLogin' => date('Y-m-d G:i:s'));


### PR DESCRIPTION
## Summary
- ensure login view checks session info before reading the user ID

## Testing
- `php -l views/system/login.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68647172ccc8833299d89c83200b14df