### PR TITLE
Fix login cookie handling for HTTP sites

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -32,11 +32,20 @@ if (file_exists(SYSTEMDIR.'Config.php')) {
 
 date_default_timezone_set(TIMEZONE);
 
+// Determine if cookies should be marked as secure.
+// If COOKIE_SECURE is enabled but HTTPS is not active, fall back to false so
+// the session cookie is still sent over HTTP. This prevents silent login
+// failures when the site has not yet been configured for HTTPS.
+$cookieSecure = COOKIE_SECURE;
+if ($cookieSecure && (empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] === 'off')) {
+    $cookieSecure = false;
+}
+
 session_set_cookie_params([
     'lifetime' => 0,
     'path' => '/',
     'domain' => $_SERVER['HTTP_HOST'],
-    'secure' => COOKIE_SECURE,
+    'secure' => $cookieSecure,
     'httponly' => COOKIE_HTTPONLY,
     'samesite' => COOKIE_SAMESITE
 ]);

--- a/system/Config-Example.php
+++ b/system/Config-Example.php
@@ -37,8 +37,12 @@ class Config {
       /* Default Session Prefix */
       define('SESSION_PREFIX', 'uc_');
 
-      /* Cookie Settings */
-      define('COOKIE_SECURE', true);
+      /* Cookie Settings
+       * Set COOKIE_SECURE to true only when the site is served over HTTPS.
+       * Using true over plain HTTP prevents the browser from sending the
+       * session cookie and will cause logins to fail.
+       */
+      define('COOKIE_SECURE', false);
       define('COOKIE_HTTPONLY', true);
       define('COOKIE_SAMESITE', 'Lax');
 


### PR DESCRIPTION
## Summary
- fallback to non-secure cookies when HTTPS isn't active
- make `COOKIE_SECURE` false by default and document when to enable it

## Testing
- `php -l public/index.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6865c019b224833286452416280aa2c0