### PR TITLE
Fix login session cookie

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -44,7 +44,8 @@ if ($cookieSecure && (empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] === 'off')) 
 session_set_cookie_params([
     'lifetime' => 0,
     'path' => '/',
-    'domain' => $_SERVER['HTTP_HOST'],
+    // Strip any port from host to ensure a valid cookie domain
+    'domain' => explode(':', $_SERVER['HTTP_HOST'])[0],
     'secure' => $cookieSecure,
     'httponly' => COOKIE_HTTPONLY,
     'samesite' => COOKIE_SAMESITE

--- a/system/core/class.Cookie.php
+++ b/system/core/class.Cookie.php
@@ -19,7 +19,8 @@ class Cookie {
         $retval = false;
         if (!headers_sent()) {
             if ($domain === false) {
-                $domain = $_SERVER['HTTP_HOST'];
+                // Strip port to avoid invalid cookie domain
+                $domain = explode(':', $_SERVER['HTTP_HOST'])[0];
             }
             $options = [
                 'expires' => $expiry,
@@ -48,7 +49,8 @@ class Cookie {
     public static function destroy($key, $value = '', $path = "/", $domain = '', $secure = false, $httponly = true, $samesite = 'Lax') {
         if (isset($_COOKIE[$key])) {
             if ($domain === '') {
-                $domain = $_SERVER['HTTP_HOST'];
+                // Strip port when defaulting domain to current host
+                $domain = explode(':', $_SERVER['HTTP_HOST'])[0];
             }
             unset($_COOKIE[$key]);
             setcookie($key, $value, [


### PR DESCRIPTION
## Summary
- revert README login troubleshooting documentation
- strip port numbers from cookie domains

## Testing
- `git diff --check`


------
https://chatgpt.com/codex/tasks/task_e_6865c582e4448332a03b71f3b15f4183