### PR TITLE
Fix secure login cookie fallback

### DIFF
--- a/system/helpers/helper.AuthHelper.php
+++ b/system/helpers/helper.AuthHelper.php
@@ -11,7 +11,7 @@
 namespace Helpers;
 
 use Core\{Cookie};
-use Helpers\{Popups, Lang, Mail, CurrentUserData};
+use Helpers\{Popups, Lang, Mail, CurrentUserData, Request};
 use Models\{AuthModel, UsersModel};
 
 class AuthHelper
@@ -347,7 +347,13 @@ class AuthHelper
         $expiretime = strtotime($expiredate);
         $info = array("uid" => $uid, "userName" => $userName, "hash" => $hash, "expiredate" => $expiredate, "ip" => $ip);
         $this->authorize->addIntoDB("sessions", $info);
-        Cookie::set(SESSION_PREFIX . 'auth_session', $hash, $expiretime, '/', false, COOKIE_SECURE, COOKIE_HTTPONLY, COOKIE_SAMESITE);
+
+        $cookieSecure = COOKIE_SECURE;
+        if ($cookieSecure && !Request::isSecure()) {
+            $cookieSecure = false;
+        }
+
+        Cookie::set(SESSION_PREFIX . 'auth_session', $hash, $expiretime, '/', false, $cookieSecure, COOKIE_HTTPONLY, COOKIE_SAMESITE);
     }
 
     /**

--- a/system/helpers/helper.Request.php
+++ b/system/helpers/helper.Request.php
@@ -138,4 +138,22 @@ class Request
     {
         return $_SERVER["REQUEST_METHOD"] === "GET";
     }
+
+    /**
+     * Detect if the request uses HTTPS.
+     *
+     * @return boolean
+     */
+    public static function isSecure()
+    {
+        if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+            return true;
+        }
+
+        if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+            return $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https';
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary
- import Request helper for AuthHelper
- add Request::isSecure to detect HTTPS
- only mark login cookie as secure when using HTTPS

## Testing
- `php -l system/helpers/helper.AuthHelper.php`
- `php -l system/helpers/helper.Request.php`
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6871be6318b483329cbfd14ff27fd6fb