### PR TITLE
Fix HTTPS login cookie detection

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -37,7 +37,7 @@ date_default_timezone_set(TIMEZONE);
 // the session cookie is still sent over HTTP. This prevents silent login
 // failures when the site has not yet been configured for HTTPS.
 $cookieSecure = COOKIE_SECURE;
-if ($cookieSecure && (empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] === 'off')) {
+if ($cookieSecure && !Helpers\Request::isSecure()) {
     $cookieSecure = false;
 }
 


### PR DESCRIPTION
## Summary
- use `Request::isSecure()` when configuring the session cookie

## Testing
- `php -l public/index.php`
- `php -l system/helpers/helper.Request.php`

------
https://chatgpt.com/codex/tasks/task_e_6871c400b4b08332b1d9d51258165b0e