### PR TITLE
Enhance session security

### DIFF
--- a/database_default.sql
+++ b/database_default.sql
@@ -102,9 +102,10 @@ CREATE TABLE `uc_sessions` (
   `id` int NOT NULL,
   `uid` int DEFAULT NULL,
   `username` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `hash` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `hash` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `expiredate` datetime DEFAULT NULL,
-  `ip` varchar(39) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL
+  `ip` varchar(39) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `useragent` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------

--- a/public/index.php
+++ b/public/index.php
@@ -32,6 +32,10 @@ if (file_exists(SYSTEMDIR.'Config.php')) {
 
 date_default_timezone_set(TIMEZONE);
 
+// Enforce strict session id mode and custom name
+ini_set('session.use_strict_mode', '1');
+session_name(SESSION_PREFIX . 'sid');
+
 // Determine if cookies should be marked as secure.
 // If COOKIE_SECURE is enabled but HTTPS is not active, fall back to false so
 // the session cookie is still sent over HTTP. This prevents silent login

--- a/system/models/model.AuthModel.php
+++ b/system/models/model.AuthModel.php
@@ -242,13 +242,13 @@ class AuthModel extends Models
     }
 
     /**
-     * Gets session info by the hash
-     * @param $hash
+     * Gets session info by the session hash
+     * @param string $hash
      * @return array dataset
      */
     public function sessionInfo($hash)
     {
-        return $this->db->select("SELECT uid, userName, expiredate, ip FROM ".PREFIX."sessions WHERE hash=:hash", array(':hash' => $hash));
+        return $this->db->select("SELECT uid, userName, expiredate, ip, useragent FROM ".PREFIX."sessions WHERE hash=:hash", array(':hash' => $hash));
     }
 
     /**


### PR DESCRIPTION
## Summary
- enforce strict session IDs and custom name
- hash session tokens and track user agents
- validate sessions with IP and User-Agent
- store hashed tokens in database

## Testing
- `php -l system/helpers/helper.AuthHelper.php`
- `php -l system/models/model.AuthModel.php`
- `php -l public/index.php`
- `php -l database_default.sql`


------
https://chatgpt.com/codex/tasks/task_e_6871c6fdf51483329242c59c087e0ca1