### PR TITLE
Fix logout success message

### DIFF
--- a/views/system/Logout.php
+++ b/views/system/Logout.php
@@ -15,4 +15,4 @@ if ($authHelper->isLogged()) {
     $authHelper->logout();
 }
 /** Success Message Display **/
-Popups::pushSuccess(Lang::get($userLocale,'logout' ), '');
+Popups::pushSuccess(Lang::get($userLocale,'logout' ), 'Login');


### PR DESCRIPTION
## Summary
- redirect users to the Login page after logging out so the success popup is shown

## Testing
- `php -v`

------
https://chatgpt.com/codex/tasks/task_e_6871d09e897883329ee8c7c2044a80b4